### PR TITLE
Version 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-diff-json",
   "description": "Grunt task that compares json files.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "https://github.com/openknowl/grunt-diff-json",
   "author": {
     "name": "openknowl",
@@ -24,15 +24,15 @@
   },
   "devDependencies": {
     "grunt-contrib-jshint": "^0.9.2",
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.5"
   },
   "keywords": [
     "gruntplugin"
   ],
   "dependencies": {
-    "deep-diff": "^0.3.2"
+    "deep-diff": "^1.0.0"
   }
 }


### PR DESCRIPTION
This update is to remove unnecessary warning message when `npm install`.
see: https://gruntjs.com/upgrading-from-0.4-to-1.0